### PR TITLE
docs/#9 : 배포 링크를 리드미에 추가한다

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,14 @@
-language: "ko-KR";
+language: 'ko-KR'
 
-reviews: profile: "chill";
-request_changes_workflow: false;
-high_level_summary: true;
-poem: false;
-review_status: true;
-auto_review: enabled: true;
-drafts: false;
+reviews:
+    profile: 'chill'
+
+request_changes_workflow: false
+high_level_summary: true
+poem: false
+review_status: true
+
+auto_review:
+    enabled: true
+
+drafts: false

--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 
 ### 프로젝트 문서화 링크
 
+-   [프로젝트 배포 링크](https://portfolio-cms-omega-one.vercel.app/)
 -   [Figma 디자인 링크](https://www.figma.com/design/lOHebWeVlXHgRWbznkW96l/personal-project?node-id=0-1&t=sp4PZcnbT4U1yF1M-1)
 -   [프로젝트 문서화 링크](https://confused-dietician-c17.notion.site/20c7caa087bd8009a57ec5872c2d09c7?source=copy_link)

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -28,15 +28,15 @@ export default tseslint.config({
       tsconfigRootDir: import.meta.dirname,
     },
   },
-})
+});
 ```
 
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js
 // eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+import reactX from 'eslint-plugin-react-x';
+import reactDom from 'eslint-plugin-react-dom';
 
 export default tseslint.config({
   plugins: {
@@ -50,5 +50,5 @@ export default tseslint.config({
     ...reactX.configs['recommended-typescript'].rules,
     ...reactDom.configs.recommended.rules,
   },
-})
+});
 ```


### PR DESCRIPTION
## 연관된 이슈
> #9 

## 작업 내용
- 버셀을 활용한 프로젝트 배포

close #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a "프로젝트 배포 링크" with the project's deployment URL to the main README.
  - Updated code snippets in the frontend README to consistently use semicolons at the end of import statements and function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->