### PR TITLE
feat: 디자인 시스템 색상 설정 및 버튼 컴포넌트 커스터마이징

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,39 +1,45 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
-
-import { cn } from "@/lib/utils"
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        // 등록, 추가, 링크이동
+        primary: 'bg-[#2563EB] text-white hover:bg-[#2B76F4] shadow-xs',
+
+        // 수정
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+          'bg-[#FFFFFF] text-[#2563EB] border border-[#2563EB] hover:bg-[#F0F7FF] shadow-xs',
+
+        // 취소, 돌아가기
+        ghost: 'bg-transparent text-[#6B7280] hover:text-[#374151]',
+
+        // 미리보기
+        utility: 'bg-[#F76666] text-[#FFFFFF] hover:bg-[#FCA5A5] shadow-xs',
+
+        // 삭제
+        danger: 'bg-[#FECACA] text-[#B91C1C] hover:bg-[#991B1B] shadow-xs',
+
+        // 깃헙 사이트 이동, 상세보기
+        external: 'bg-[#000000] text-white hover:opacity-80 shadow-xs',
       },
       size: {
-        default: "h-9 px-4 py-2 has-[>svg]:px-3",
-        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
-        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
-        icon: "size-9",
+        default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+        lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
+        icon: 'size-9',
       },
     },
     defaultVariants: {
-      variant: "default",
-      size: "default",
+      variant: 'primary',
+      size: 'default',
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -41,11 +47,11 @@ function Button({
   size,
   asChild = false,
   ...props
-}: React.ComponentProps<"button"> &
+}: React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
+    asChild?: boolean;
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp = asChild ? Slot : 'button';
 
   return (
     <Comp
@@ -53,7 +59,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };


### PR DESCRIPTION
## 연관된 이슈
> #11 

## 작업 내용
- 프로젝트 디자인 시스템에 맞게 색상 체계를 역할별/위계별로 구분하고 설정하였습니다.
- shadcn/ui 기본 버튼 스타일을 기반으로, 프로젝트 전용 **버튼 variant (primary, secondary, danger, ghost, 등)** 색상을 디자인 시스템에 맞게 적용하여 커스터마이징하였습니다.

### 스크린샷 (선택)
<img width="352" alt="스크린샷 2025-06-27 오전 9 35 47" src="https://github.com/user-attachments/assets/3dc6f26e-43c7-48f8-a8fc-3981a707bdf0" />
<img width="776" alt="스크린샷 2025-06-27 오전 9 35 58" src="https://github.com/user-attachments/assets/ea4a9e41-83f5-41fa-b74f-d2050426c939" />

close #11